### PR TITLE
replacement of 連想配列 to 連想リスト

### DIFF
--- a/lispref/translation_HEAD/html/Association-Lists.html
+++ b/lispref/translation_HEAD/html/Association-Lists.html
@@ -69,7 +69,7 @@ Next: <a href="Property-Lists.html" accesskey="n" rel="next">プロパティリ�
 <span id="index-association-list"></span>
 <span id="index-alist"></span>
 
-<p><em>連想配列(association
+<p><em>連想リスト(association
 list、短くはalist)</em>は、キーと値のマッピングを記録します。これは<em>連想(associations)</em>と呼ばれるコンスセルのリストです。各コンスセルにおいて<small>CAR</small>は<em>キー(key)</em>で、<small>CDR</small>は<em>連想値(associated
 value)</em>となります。<a id="DOCF6" href="#FOOT6"><sup>6</sup></a>
 </p>

--- a/lispref/translation_HEAD/html/Auto-Major-Mode.html
+++ b/lispref/translation_HEAD/html/Auto-Major-Mode.html
@@ -134,7 +134,7 @@ Manual</cite>を参照のこと。<code>enable-local-variables</code>が<code>ni
 
 <dl class="def">
 <dt id="index-auto_002dmode_002dalist"><span class="category">Variable: </span><span><strong>auto-mode-alist</strong><a href='#index-auto_002dmode_002dalist' class='copiable-anchor'> &para;</a></span></dt>
-<dd><p>この変数はファイル名パターン(正規表現)と対応するメジャーモードコマンドの連想配列を含む。ファイル名パターンは通常は&lsquo;<samp>.el</samp>&rsquo;や&lsquo;<samp>.c</samp>&rsquo;のようなサフィックスをテストするが必須ではない。このalistの通常の要素は<code>(<var>regexp</var>
+<dd><p>この変数はファイル名パターン(正規表現)と対応するメジャーモードコマンドの連想リストを含む。ファイル名パターンは通常は&lsquo;<samp>.el</samp>&rsquo;や&lsquo;<samp>.c</samp>&rsquo;のようなサフィックスをテストするが必須ではない。このalistの通常の要素は<code>(<var>regexp</var>
 .  <var>mode-function</var>)</code>のようになる。
 </p>
 <p>たとえば、

--- a/lispref/translation_HEAD/html/Desktop-Save-Mode.html
+++ b/lispref/translation_HEAD/html/Desktop-Save-Mode.html
@@ -84,7 +84,7 @@ Manual</cite>を参照)。バッファーでファイルをvisitしているモ�
 
 </dd></dl>
 
-<p>ファイルをvisitしていないバッファーがリストアされるようにするには、メジャーモードがその処理を行う関数を定義しなければならず、その関数は連想配列<code>desktop-buffer-mode-handlers</code>にリストされなければならない。
+<p>ファイルをvisitしていないバッファーがリストアされるようにするには、メジャーモードがその処理を行う関数を定義しなければならず、その関数は連想リスト<code>desktop-buffer-mode-handlers</code>にリストされなければならない。
 </p>
 <dl class="def">
 <dt id="index-desktop_002dbuffer_002dmode_002dhandlers"><span class="category">Variable: </span><span><strong>desktop-buffer-mode-handlers</strong><a href='#index-desktop_002dbuffer_002dmode_002dhandlers' class='copiable-anchor'> &para;</a></span></dt>

--- a/lispref/translation_HEAD/html/Programmed-Completion.html
+++ b/lispref/translation_HEAD/html/Programmed-Completion.html
@@ -105,7 +105,7 @@ completion)</em>と呼ばれます。Emacsは数あるケースの中でも特�
 </dd>
 <dt><span><code>metadata</code></span></dt>
 <dd><p>カレント補完の状態に関する情報の要求を指定する。リターン値は<code>(metadata
-. <var>alist</var>)</code>の形式をもち、<var>alist</var>は以下で説明する要素をもつ連想配列。
+. <var>alist</var>)</code>の形式をもち、<var>alist</var>は以下で説明する要素をもつ連想リスト。
 </p></dd>
 </dl>
 

--- a/lispref/translation_HEAD/html/Scanning-Keymaps.html
+++ b/lispref/translation_HEAD/html/Scanning-Keymaps.html
@@ -75,7 +75,7 @@ Next: <a href="Menu-Keymaps.html" accesskey="n" rel="next">メニューキーア
 <dt id="index-accessible_002dkeymaps"><span class="category">Function: </span><span><strong>accessible-keymaps</strong> <em>keymap &amp;optional prefix</em><a href='#index-accessible_002dkeymaps' class='copiable-anchor'> &para;</a></span></dt>
 <dd><p>この関数は、(0個以上のプレフィクスキーを通じて)<var>keymap</var>から到達可能なすべてのキーマップのリストをリターンする。リターン値は<code>(<var>key</var>
 .
-<var>map</var>)</code>のような形式の要素をもつ連想配列(alist)である。ここで<var>key</var>は<var>keymap</var>内での定義が<var>map</var>であるようなプレフィクスキーである。
+<var>map</var>)</code>のような形式の要素をもつ連想リスト(alist)である。ここで<var>key</var>は<var>keymap</var>内での定義が<var>map</var>であるようなプレフィクスキーである。
 </p>
 <p>alistの要素は<var>key</var>の長さにたいして昇順にソートされている。1つ目の要素は常に<code>([] .
 <var>keymap</var>)</code>。これは指定されたキーマップがイベントなしのプレフィクスによって、自分自身からアクセス可能だからである。


### PR DESCRIPTION
「連想配列」を「連想リスト」とするべきではないかと思ったところです．